### PR TITLE
Search box stays interactable

### DIFF
--- a/StashSearch/StashComponent.cs
+++ b/StashSearch/StashComponent.cs
@@ -1,4 +1,4 @@
-﻿using Aki.Reflection.Utils;
+using Aki.Reflection.Utils;
 using Comfort.Common;
 using EFT;
 using EFT.InventoryLogic;
@@ -114,12 +114,12 @@ namespace StashSearch
         {
             Plugin.Log.LogDebug($"Search Input: {_inputField.text}");
 
-            // don't bother searching if term is the same as current search
-            if (_inputField.text == _searchController.CurrentSearchString) yield break;
-
             // clear search if one is already pending
             if (_searchController.IsSearchedState)
             {
+                // don't bother searching if term is the same as current search
+                if (_inputField.text == _searchController.CurrentSearchString) yield break;
+
                 yield return ClearSearch(false);
             }
 

--- a/StashSearch/StashComponent.cs
+++ b/StashSearch/StashComponent.cs
@@ -1,4 +1,4 @@
-using Aki.Reflection.Utils;
+﻿using Aki.Reflection.Utils;
 using Comfort.Common;
 using EFT;
 using EFT.InventoryLogic;
@@ -80,6 +80,11 @@ namespace StashSearch
 
             _searchController = new SearchController();
             Plugin.SearchControllers.Add(_searchController);
+        }
+
+        private void OnDisable()
+        {
+            _inputField.text = string.Empty;
         }
 
         private void Update()

--- a/StashSearch/TraderScreenComponent.cs
+++ b/StashSearch/TraderScreenComponent.cs
@@ -1,4 +1,4 @@
-﻿using EFT;
+using EFT;
 using EFT.InventoryLogic;
 using EFT.UI;
 using EFT.UI.DragAndDrop;
@@ -177,12 +177,12 @@ namespace StashSearch
 
         private IEnumerator SearchStash()
         {
-            // don't bother searching if term is the same as current search
-            if (_inputFieldPlayer.text == _searchControllerPlayer.CurrentSearchString) yield break;
-
             // clear search if one is already pending
             if (_searchControllerPlayer.IsSearchedState)
             {
+                // don't bother searching if term is the same as current search
+                if (_inputFieldPlayer.text == _searchControllerPlayer.CurrentSearchString) yield break;
+
                 // avoid losing items if trading table not empty
                 if (!CheckTradingTableEmpty())
                 {
@@ -235,12 +235,12 @@ namespace StashSearch
 
         private IEnumerator SearchTrader()
         {
-            // don't bother searching if term is the same as current search
-            if (_inputFieldTrader.text == _searchControllerTrader.CurrentSearchString) yield break;
-
             // clear search if one is already pending
             if (_searchControllerTrader.IsSearchedState)
             {
+                // don't bother searching if term is the same as current search
+                if (_inputFieldTrader.text == _searchControllerTrader.CurrentSearchString) yield break;
+
                 yield return ClearTraderSearch(false);
             }
 

--- a/StashSearch/TraderScreenComponent.cs
+++ b/StashSearch/TraderScreenComponent.cs
@@ -1,4 +1,4 @@
-using EFT;
+﻿using EFT;
 using EFT.InventoryLogic;
 using EFT.UI;
 using EFT.UI.DragAndDrop;
@@ -126,6 +126,12 @@ namespace StashSearch
 
             // Adjust the trader UI
             AdjustTraderUI();
+        }
+
+        private void OnDisable()
+        {
+            _inputFieldPlayer.text = string.Empty;
+            _inputFieldTrader.text = string.Empty;
         }
 
         private void Update()

--- a/StashSearch/TraderScreenComponent.cs
+++ b/StashSearch/TraderScreenComponent.cs
@@ -119,10 +119,10 @@ namespace StashSearch
             // Add our listeners
 
             _inputFieldPlayer.onEndEdit.AddListener(delegate { StaticManager.BeginCoroutine(SearchStash()); });
-            _searchRestoreButtonPlayer.onClick.AddListener(delegate { StaticManager.BeginCoroutine(ClearStashSearch()); });
+            _searchRestoreButtonPlayer.onClick.AddListener(delegate { StaticManager.BeginCoroutine(ClearStashSearch(true)); });
 
             _inputFieldTrader.onEndEdit.AddListener(delegate { StaticManager.BeginCoroutine(SearchTrader()); });
-            _searchRestoreButtonTrader.onClick.AddListener(delegate { StaticManager.BeginCoroutine(ClearTraderSearch()); });
+            _searchRestoreButtonTrader.onClick.AddListener(delegate { StaticManager.BeginCoroutine(ClearTraderSearch(true)); });
 
             // Adjust the trader UI
             AdjustTraderUI();
@@ -148,11 +148,11 @@ namespace StashSearch
             {
                 if (SearchController.LastSearchedGrid == GridViewOwner.PlayerTradingScreen)
                 {
-                    StaticManager.BeginCoroutine(ClearStashSearch());
+                    StaticManager.BeginCoroutine(ClearStashSearch(true));
                 }
                 else if (SearchController.LastSearchedGrid == GridViewOwner.Trader)
                 {
-                    StaticManager.BeginCoroutine(ClearTraderSearch());
+                    StaticManager.BeginCoroutine(ClearTraderSearch(true));
                 }
             }
         }
@@ -177,10 +177,22 @@ namespace StashSearch
 
         private IEnumerator SearchStash()
         {
-            if (_inputFieldPlayer.text == string.Empty) yield break;
+            // don't bother searching if term is the same as current search
+            if (_inputFieldPlayer.text == _searchControllerPlayer.CurrentSearchString) yield break;
 
-            // Disable the input, so the user can't search over a search
-            _inputFieldPlayer.enabled = false;
+            // clear search if one is already pending
+            if (_searchControllerPlayer.IsSearchedState)
+            {
+                // avoid losing items if trading table not empty
+                if (!CheckTradingTableEmpty())
+                {
+                    yield break;
+                }
+
+                yield return ClearStashSearch(false);
+            }
+
+            if (_inputFieldPlayer.text == string.Empty) yield break;
 
             // Recursively search, starting at the player stash
             HashSet<Item> searchResult = _searchControllerPlayer.Search(_inputFieldPlayer.text.ToLower(), _gridViewPlayer.Grid, _gridViewPlayer.Grid.Id);
@@ -197,15 +209,11 @@ namespace StashSearch
             yield break;
         }
 
-        private IEnumerator ClearStashSearch()
+        private IEnumerator ClearStashSearch(bool clearText)
         {
-            if (_gridViewTradingTable?.Grid?.ItemCollection != null && _gridViewTradingTable.Grid.ItemCollection.Count > 0)
+            // avoid losing items if trading table not empty
+            if (!CheckTradingTableEmpty())
             {
-                NotificationManagerClass.DisplayMessageNotification(
-                        "Cannot clear search with items in the trading table.",
-                        EFT.Communications.ENotificationDurationType.Default,
-                        EFT.Communications.ENotificationIconType.Alert);
-
                 yield break;
             }
 
@@ -215,9 +223,10 @@ namespace StashSearch
             _searchControllerPlayer.RefreshGridView(_gridViewPlayer);
             _scrollRectPlayer.normalizedPosition = Vector3.up;
 
-            // Enable user input
-            _inputFieldPlayer.enabled = true;
-            _inputFieldPlayer.text = string.Empty;
+            if (clearText)
+            {
+                _inputFieldPlayer.text = string.Empty;
+            }
 
             AccessTools.Field(typeof(GridView), "_nonInteractable").SetValue(_gridViewPlayer, false);
 
@@ -226,10 +235,16 @@ namespace StashSearch
 
         private IEnumerator SearchTrader()
         {
-            if (_inputFieldTrader.text == string.Empty) yield break;
+            // don't bother searching if term is the same as current search
+            if (_inputFieldTrader.text == _searchControllerTrader.CurrentSearchString) yield break;
 
-            // Disable the input, so the user can't search over a search
-            _inputFieldTrader.enabled = false;
+            // clear search if one is already pending
+            if (_searchControllerTrader.IsSearchedState)
+            {
+                yield return ClearTraderSearch(false);
+            }
+
+            if (_inputFieldTrader.text == string.Empty) yield break;
 
             // Search the trader
             HashSet<Item> searchResult = _searchControllerTrader.Search(_inputFieldTrader.text.ToLower(), _gridViewTrader.Grid, _gridViewTrader.Grid.Id);
@@ -238,7 +253,7 @@ namespace StashSearch
             SearchController.LastSearchedGrid = GridViewOwner.Trader;
 
             // refresh the UI
-            _searchControllerPlayer.RefreshGridView(_gridViewTrader, searchResult);
+            _searchControllerTrader.RefreshGridView(_gridViewTrader, searchResult);
             _scrollRectTrader.normalizedPosition = Vector3.up;
 
             AccessTools.Field(typeof(GridView), "_nonInteractable").SetValue(_gridViewTrader, true);
@@ -246,21 +261,36 @@ namespace StashSearch
             yield break;
         }
 
-        private IEnumerator ClearTraderSearch()
+        private IEnumerator ClearTraderSearch(bool clearText)
         {
             _searchControllerTrader.RestoreHiddenItems(_gridViewTrader.Grid);
 
             // refresh the UI
-            _searchControllerPlayer.RefreshGridView(_gridViewTrader);
+            _searchControllerTrader.RefreshGridView(_gridViewTrader);
             _scrollRectTrader.normalizedPosition = Vector3.up;
 
-            // Enable user input
-            _inputFieldTrader.enabled = true;
-            _inputFieldTrader.text = string.Empty;
+            if (clearText)
+            {
+                _inputFieldTrader.text = string.Empty;
+            }
 
             AccessTools.Field(typeof(GridView), "_nonInteractable").SetValue(_gridViewTrader, false);
 
             yield break;
+        }
+
+        private bool CheckTradingTableEmpty()
+        {
+            if (_gridViewTradingTable?.Grid?.ItemCollection != null && _gridViewTradingTable.Grid.ItemCollection.Count > 0)
+            {
+                NotificationManagerClass.DisplayMessageNotification(
+                        "Cannot clear search with items in the trading table.",
+                        EFT.Communications.ENotificationDurationType.Default,
+                        EFT.Communications.ENotificationIconType.Alert);
+                return false;
+            }
+
+            return true;
         }
     }
 }

--- a/StashSearch/Utils/AbstractSearchController.cs
+++ b/StashSearch/Utils/AbstractSearchController.cs
@@ -6,6 +6,7 @@ namespace StashSearch.Utils
     internal abstract class AbstractSearchController
     {
         public bool IsSearchedState;
+        public string CurrentSearchString;
         public bool IsTrader;
         public StashGridClass SearchedGrid;
         public string ParentGridId;

--- a/StashSearch/Utils/SearchController.cs
+++ b/StashSearch/Utils/SearchController.cs
@@ -30,6 +30,7 @@ namespace StashSearch.Utils
         public HashSet<Item> Search(string searchString, StashGridClass gridToSearch, string parentGridID)
         {
             IsSearchedState = true;
+            CurrentSearchString = searchString;
             ParentGridId = parentGridID;
 
             // Set context of what grid we searched
@@ -91,6 +92,7 @@ namespace StashSearch.Utils
 
                 // Reset the search state
                 IsSearchedState = false;
+                CurrentSearchString = string.Empty;
                 SearchedGrid = null;
             }
             catch (Exception e)


### PR DESCRIPTION
This changes the behavior to allow search while a search is already active, by clearing the search first if one is in progress before performing the next search, keeping the search box interactable the whole time.

I debated doing this a couple of different ways, but this was what I ultimately landed on. It might be possible to refactor things a bit to deduplicate the `*Component`s a bit, since effectively we have three copies of the same basic logic. There is also the thought that this could happen outside of the `*Component`s and inside `SearchController`, but this felt better initially, since ultimately it's UI logic. My original idea was just to affect the keybind, but it didn't feel good to have different behavior when clicking on the box. This also resolves the issue of unexpected behavior after closing the stash screen to the main menu while still having a search going. On master, this makes it so that you have to clear the search, even though there is no real search active, just that the search field is disabled.

There is a bit of a flash of the inventory between searches. This might be avoided by changing some stuff around, I'm not particularly familiar with Tarkov.

We can of course discuss the approach, if you feel like this is a bad one.


Misc other changes:

* In stash search, if searching and press keybind, highlight the search
* When `*Component` is disabled, clear the text in the search input fields, since the code in `OnScreenChangedPatch.cs` will actually restore the items to their place