### PR TITLE
Fix issue with quick moving items to stash during search

### DIFF
--- a/StashSearch/Patches/CanQuickMoveToPatch.cs
+++ b/StashSearch/Patches/CanQuickMoveToPatch.cs
@@ -1,0 +1,37 @@
+﻿using Aki.Reflection.Patching;
+using EFT.InventoryLogic;
+using HarmonyLib;
+using System.Reflection;
+
+namespace StashSearch.Patches
+{
+    internal class CanQuickMoveToPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return AccessTools.Method(typeof(ItemContextAbstractClass), nameof(ItemContextAbstractClass.CanQuickMoveTo));
+        }
+
+        /// <summary>
+        /// Prevents item loss by not allowing quick moves to stash while searching
+        /// </summary>
+        /// <returns></returns>
+        [PatchPostfix]
+        public static void PatchPostfix(ETargetContainer targetContainer, ref bool __result)
+        {
+            if (!__result || (targetContainer != ETargetContainer.Stash))
+            {
+                return;
+            }
+
+            foreach (var controller in Plugin.SearchControllers)
+            {
+                if (controller.IsSearchedState)
+                {
+                    __result = false;
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/StashSearch/Patches/SortingTablePatch.cs
+++ b/StashSearch/Patches/SortingTablePatch.cs
@@ -17,7 +17,7 @@ namespace StashSearch.Patches
         /// </summary>
         /// <returns></returns>
         [PatchPrefix]
-        public static bool PatchPostfix()
+        public static bool PatchPrefix()
         {
             foreach (var controller in Plugin.SearchControllers)
             {

--- a/StashSearch/Plugin.cs
+++ b/StashSearch/Plugin.cs
@@ -54,6 +54,7 @@ namespace StashSearch
             new TraderScreenGroupPatch().Enable();
             new OnScreenChangedPatch().Enable();
             new SortingTablePatch().Enable();
+            new CanQuickMoveToPatch().Enable();
         }
 
         private void Start()


### PR DESCRIPTION
CTRL-clicking items in inventory or sorting table to quick move them during search could result in apparent loss of the item. This resolves that.