### PR TITLE
Clear trader search text when changing traders

### DIFF
--- a/StashSearch/Patches/TraderDealScreenShowPatch.cs
+++ b/StashSearch/Patches/TraderDealScreenShowPatch.cs
@@ -1,0 +1,30 @@
+﻿using Aki.Reflection.Patching;
+using EFT.UI;
+using HarmonyLib;
+using System.Reflection;
+
+namespace StashSearch.Patches
+{
+    internal class TraderDealScreenShowPatch : ModulePatch
+    {
+        public static TraderScreenComponent TraderScreenComponent;
+
+        protected override MethodBase GetTargetMethod()
+        {
+            return AccessTools.FirstMethod(typeof(TraderDealScreen), 
+                x => x.Name == nameof(TraderDealScreen.Show)
+                && x.GetParameters()[0].Name == "trader");
+        }
+
+        [PatchPostfix]
+        public static void PatchPostfix(TraderClass trader)
+        {
+            if (!TraderScreenComponent)
+            {
+                return;
+            }
+
+            TraderScreenComponent.MaybeChangeTrader(trader);
+        }
+    }
+}

--- a/StashSearch/Patches/TraderScreensGroupShowPatch.cs
+++ b/StashSearch/Patches/TraderScreensGroupShowPatch.cs
@@ -5,9 +5,9 @@ using System.Reflection;
 
 namespace StashSearch.Patches
 {
-    internal class TraderScreenGroupPatch : ModulePatch
+    internal class TraderScreensGroupShowPatch : ModulePatch
     {
-        public static TraderScreensGroup TraderDealGroup;
+        public static TraderScreensGroup TraderScreensGroup;
 
         protected override MethodBase GetTargetMethod()
         {
@@ -19,13 +19,16 @@ namespace StashSearch.Patches
         [PatchPostfix]
         public static void PatchPostfix(TraderScreensGroup __instance)
         {
-            if (TraderDealGroup)
+            if (TraderScreensGroup)
             {
                 return;
             }
 
-            TraderDealGroup = __instance;
-            Plugin.Instance.AttachToTraderScreen(TraderDealGroup);
+            TraderScreensGroup = __instance;
+            var traderSearchGO = Plugin.Instance.AttachToTraderScreen(TraderScreensGroup);
+
+            // save component to the other patch
+            TraderDealScreenShowPatch.TraderScreenComponent = traderSearchGO.GetComponent<TraderScreenComponent>();
         }
     }
 }

--- a/StashSearch/Plugin.cs
+++ b/StashSearch/Plugin.cs
@@ -50,7 +50,8 @@ namespace StashSearch
 
             new GridViewShowPatch().Enable();
             new InventoryScreenShowPatch().Enable();
-            new TraderScreenGroupPatch().Enable();
+            new TraderScreensGroupShowPatch().Enable();
+            new TraderDealScreenShowPatch().Enable();
             new OnScreenChangedPatch().Enable();
             new SortingTablePatch().Enable();
             new CanQuickMoveToPatch().Enable();
@@ -61,18 +62,20 @@ namespace StashSearch
             LoadBundle();
         }
 
-        public void AttachToInventoryScreen(InventoryScreen inventory)
+        public GameObject AttachToInventoryScreen(InventoryScreen inventory)
         {
             // create a new gameobject parented under InventoryScreen with our component on it
             StashSearchGameObject = new GameObject("StashSearch", typeof(StashComponent));
             StashSearchGameObject.transform.SetParent(inventory.transform);
+            return StashSearchGameObject;
         }
 
-        public void AttachToTraderScreen(TraderScreensGroup traderScreensGroup)
+        public GameObject AttachToTraderScreen(TraderScreensGroup traderScreensGroup)
         {
             // create a new gameobject parented under TraderScreensGroup with our component on it
             TraderSearchGameObject = new GameObject("TraderSearch", typeof(TraderScreenComponent));
             TraderSearchGameObject.transform.SetParent(traderScreensGroup.transform);
+            return TraderSearchGameObject;
         }
 
         private void LoadBundle()

--- a/StashSearch/TraderScreenComponent.cs
+++ b/StashSearch/TraderScreenComponent.cs
@@ -19,6 +19,7 @@ namespace StashSearch
     {
         private TraderScreensGroup _traderDealGroup;
         private TraderDealScreen _traderDealScreen;
+        private TraderClass _lastTrader;
 
         // "Left Player" and "Right Player" stash transforms
         private RectTransform _rectTransformTrader;
@@ -66,7 +67,7 @@ namespace StashSearch
 
         private void Awake()
         {
-            _traderDealGroup = TraderScreenGroupPatch.TraderDealGroup;
+            _traderDealGroup = TraderScreensGroupShowPatch.TraderScreensGroup;
             _traderDealScreen = (TraderDealScreen)AccessTools.Field(typeof(TraderScreensGroup), "_traderDealScreen").GetValue(_traderDealGroup);
 
             _scrollRectPlayer = (ScrollRect)AccessTools.Field(typeof(TraderDealScreen), "_stashScroll").GetValue(_traderDealScreen);
@@ -129,8 +130,10 @@ namespace StashSearch
 
         private void OnDisable()
         {
+            // clear search field and _lastTrader
             _inputFieldPlayer.text = string.Empty;
             _inputFieldTrader.text = string.Empty;
+            _lastTrader = null;
 
             // NOTE: could potentially clear search here rather than having the OnScreenChangedPatch do it
         }
@@ -162,6 +165,20 @@ namespace StashSearch
                     StaticManager.BeginCoroutine(ClearTraderSearch(true));
                 }
             }
+        }
+
+        public void MaybeChangeTrader(TraderClass trader)
+        {
+            // clear search after trader changes
+            if (_searchControllerTrader.IsSearchedState && _lastTrader != trader)
+            {
+                _inputFieldTrader.text = string.Empty;
+
+                // HACK: clear the current search string to allow repeat search without going through normal clear
+                _searchControllerTrader.CurrentSearchString = string.Empty;
+            }
+
+            _lastTrader = trader;
         }
 
         private void AdjustTraderUI()


### PR DESCRIPTION
This fixes the issue that trader searches are not cleared when changing traders. Long term, it would be better to actually "keep" the search going by waiting until the assortment/grid is fully updated and then searching the new trader. This was non-trivial when I looked into it.

Minor Changes:
- Some renames to patches to match what they're actually doing