### PR TITLE
Add autocomplete feature

### DIFF
--- a/StashSearch/Patches/TraderDealScreenShowPatch.cs
+++ b/StashSearch/Patches/TraderDealScreenShowPatch.cs
@@ -16,15 +16,15 @@ namespace StashSearch.Patches
                 && x.GetParameters()[0].Name == "trader");
         }
 
-        [PatchPostfix]
-        public static void PatchPostfix(TraderClass trader)
+        [PatchPrefix]
+        public static void PatchPrefix(TraderClass trader)
         {
             if (!TraderScreenComponent)
             {
                 return;
             }
 
-            TraderScreenComponent.MaybeChangeTrader(trader);
+            TraderScreenComponent.MaybeChangingTrader(trader);
         }
     }
 }

--- a/StashSearch/StashComponent.cs
+++ b/StashSearch/StashComponent.cs
@@ -23,6 +23,8 @@ namespace StashSearch
 
         private SearchController _searchController;
 
+        private AutoCompleteComponent _autoCompleteComponent;
+
         // Search GameObject and TMP_InputField
         private GameObject _searchObject;
 
@@ -80,6 +82,8 @@ namespace StashSearch
 
             _searchController = new SearchController();
             Plugin.SearchControllers.Add(_searchController);
+
+            _autoCompleteComponent = _searchObject.AddComponent<AutoCompleteComponent>();
         }
 
         private void OnEnable()
@@ -101,6 +105,8 @@ namespace StashSearch
             _complexStash.RectTransform.sizeDelta = new Vector2(680, -260);
             _complexStash.Transform.localPosition = new Vector3(948, 12, 0);
             _hasMovedComplexStash = true;
+
+            _autoCompleteComponent.ParseKeywordsFromGrid(_playerStash.Grid);
         }
 
         private void OnDisable()

--- a/StashSearch/StashComponent.cs
+++ b/StashSearch/StashComponent.cs
@@ -87,7 +87,9 @@ namespace StashSearch
             _searchController = new SearchController();
             Plugin.SearchControllers.Add(_searchController);
 
+            // add autocomplete and populate autocomplete onselect
             _autoCompleteComponent = _searchObject.AddComponent<AutoCompleteComponent>();
+            _inputField.onSelect.AddListener((_) => PopulateAutoComplete());
         }
 
         private void OnEnable()
@@ -110,8 +112,6 @@ namespace StashSearch
             _complexStash.Transform.localPosition = new Vector3(948, 12, 0);
             _hasMovedComplexStash = true;
 
-            // populate autocomplete each time that the search is selected
-            _inputField.onSelect.AddListener((_) => PopulateAutoComplete());
         }
 
         private void OnDisable()

--- a/StashSearch/StashComponent.cs
+++ b/StashSearch/StashComponent.cs
@@ -25,7 +25,7 @@ namespace StashSearch
 
         private SearchController _searchController;
 
-        private AutoCompleteComponent _autoCompleteComponent;
+        private InputFieldAutoComplete _autoCompleteComponent;
         private DateTime _lastAutoCompleteFill = DateTime.MinValue;
         private readonly TimeSpan _autoCompleteThrottleTime = new(0, 0, 2); // two seconds
 
@@ -88,7 +88,7 @@ namespace StashSearch
             Plugin.SearchControllers.Add(_searchController);
 
             // add autocomplete and populate autocomplete onselect
-            _autoCompleteComponent = _searchObject.AddComponent<AutoCompleteComponent>();
+            _autoCompleteComponent = new(_inputField);
             _inputField.onSelect.AddListener((_) => PopulateAutoComplete());
         }
 
@@ -225,12 +225,12 @@ namespace StashSearch
             }
 
             // throttle this calculation
-            var timeDiff = DateTime.Now - _lastAutoCompleteFill;
+            var timeDiff = DateTime.UtcNow - _lastAutoCompleteFill;
             if (timeDiff <= _autoCompleteThrottleTime)
             {
                 return;
             }
-            _lastAutoCompleteFill = DateTime.Now;
+            _lastAutoCompleteFill = DateTime.UtcNow;
 
             // clear and add keywords from itemclasses and stash items
             _autoCompleteComponent.ClearKeywords();

--- a/StashSearch/TraderScreenComponent.cs
+++ b/StashSearch/TraderScreenComponent.cs
@@ -63,9 +63,9 @@ namespace StashSearch
 
         // autocomplete
         private readonly TimeSpan _autoCompleteThrottleTime = new(0, 0, 2); // two seconds
-        private AutoCompleteComponent _autoCompleteTrader;
+        private InputFieldAutoComplete _autoCompleteTrader;
         private DateTime _lastAutoCompleteFillTrader = DateTime.MinValue;
-        private AutoCompleteComponent _autoCompletePlayer;
+        private InputFieldAutoComplete _autoCompletePlayer;
         private DateTime _lastAutoCompleteFillPlayer = DateTime.MinValue;
 
         private bool _isPlayerGridFocused = false;
@@ -137,10 +137,10 @@ namespace StashSearch
             AdjustTraderUI();
 
             // add autocomplete and populate autocomplete onselect
-            _autoCompletePlayer = _searchBoxObjectPlayer.AddComponent<AutoCompleteComponent>();
+            _autoCompletePlayer = new(_inputFieldPlayer);
             _inputFieldPlayer.onSelect.AddListener((_) => PopulateAutoComplete(_autoCompletePlayer, _gridViewPlayer.Grid, _searchControllerPlayer, ref _lastAutoCompleteFillPlayer));
 
-            _autoCompleteTrader = _searchBoxObjectTrader.AddComponent<AutoCompleteComponent>();
+            _autoCompleteTrader = new(_inputFieldTrader);
             _inputFieldTrader.onSelect.AddListener((_) => PopulateAutoComplete(_autoCompleteTrader, _gridViewTrader.Grid, _searchControllerTrader, ref _lastAutoCompleteFillTrader));
         }
 
@@ -342,7 +342,7 @@ namespace StashSearch
             return true;
         }
 
-        private void PopulateAutoComplete(AutoCompleteComponent autoComplete, StashGridClass grid, SearchController searchController, ref DateTime lastFill)
+        private void PopulateAutoComplete(InputFieldAutoComplete autoComplete, StashGridClass grid, SearchController searchController, ref DateTime lastFill)
         {
             // don't populate if searching
             if (searchController.IsSearchedState)
@@ -351,12 +351,12 @@ namespace StashSearch
             }
 
             // throttle this calculation
-            var timeDiff = DateTime.Now - lastFill;
+            var timeDiff = DateTime.UtcNow - lastFill;
             if (timeDiff <= _autoCompleteThrottleTime)
             {
                 return;
             }
-            lastFill = DateTime.Now;
+            lastFill = DateTime.UtcNow;
 
             // clear and add keywords from itemclasses and stash items
             autoComplete.ClearKeywords();

--- a/StashSearch/TraderScreenComponent.cs
+++ b/StashSearch/TraderScreenComponent.cs
@@ -7,8 +7,10 @@ using HarmonyLib;
 using StashSearch.Config;
 using StashSearch.Patches;
 using StashSearch.Utils;
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -58,6 +60,13 @@ namespace StashSearch
 
         private ScrollRect _scrollRectPlayer;
         private ScrollRect _scrollRectTrader;
+
+        // autocomplete
+        private readonly TimeSpan _autoCompleteThrottleTime = new(0, 0, 2); // two seconds
+        private AutoCompleteComponent _autoCompleteTrader;
+        private DateTime _lastAutoCompleteFillTrader = DateTime.MinValue;
+        private AutoCompleteComponent _autoCompletePlayer;
+        private DateTime _lastAutoCompleteFillPlayer = DateTime.MinValue;
 
         private bool _isPlayerGridFocused = false;
 
@@ -126,6 +135,13 @@ namespace StashSearch
 
             // Adjust the trader UI
             AdjustTraderUI();
+
+            // add autocomplete and populate autocomplete onselect
+            _autoCompletePlayer = _searchBoxObjectPlayer.AddComponent<AutoCompleteComponent>();
+            _inputFieldPlayer.onSelect.AddListener((_) => PopulateAutoComplete(_autoCompletePlayer, _gridViewPlayer.Grid, _searchControllerPlayer, ref _lastAutoCompleteFillPlayer));
+
+            _autoCompleteTrader = _searchBoxObjectTrader.AddComponent<AutoCompleteComponent>();
+            _inputFieldTrader.onSelect.AddListener((_) => PopulateAutoComplete(_autoCompleteTrader, _gridViewTrader.Grid, _searchControllerTrader, ref _lastAutoCompleteFillTrader));
         }
 
         private void OnDisable()
@@ -144,11 +160,17 @@ namespace StashSearch
             {
                 if (_isPlayerGridFocused)
                 {
+                    // for some reason, ActivateInputField doesn't call any event
+                    PopulateAutoComplete(_autoCompleteTrader, _gridViewTrader.Grid, _searchControllerTrader, ref _lastAutoCompleteFillTrader);
+
                     _inputFieldTrader.ActivateInputField();
                     _isPlayerGridFocused = false;
                 }
                 else
                 {
+                    // for some reason, ActivateInputField doesn't call any event
+                    PopulateAutoComplete(_autoCompletePlayer, _gridViewPlayer.Grid, _searchControllerPlayer, ref _lastAutoCompleteFillPlayer);
+
                     _inputFieldPlayer.ActivateInputField();
                     _isPlayerGridFocused = true;
                 }
@@ -167,15 +189,18 @@ namespace StashSearch
             }
         }
 
-        public void MaybeChangeTrader(TraderClass trader)
+        public void MaybeChangingTrader(TraderClass trader)
         {
-            // clear search after trader changes
+            // clear search before trader changes
             if (_searchControllerTrader.IsSearchedState && _lastTrader != trader)
             {
                 _inputFieldTrader.text = string.Empty;
 
-                // HACK: clear the current search string to allow repeat search without going through normal clear
-                _searchControllerTrader.CurrentSearchString = string.Empty;
+                // HACK: clear the current search when trader is about to change 
+                _searchControllerTrader.RestoreHiddenItems(_gridViewTrader.Grid);
+
+                // reset the autocomplete throttle
+                _lastAutoCompleteFillTrader = DateTime.MinValue;
             }
 
             _lastTrader = trader;
@@ -315,6 +340,28 @@ namespace StashSearch
             }
 
             return true;
+        }
+
+        private void PopulateAutoComplete(AutoCompleteComponent autoComplete, StashGridClass grid, SearchController searchController, ref DateTime lastFill)
+        {
+            // don't populate if searching
+            if (searchController.IsSearchedState)
+            {
+                return;
+            }
+
+            // throttle this calculation
+            var timeDiff = DateTime.Now - lastFill;
+            if (timeDiff <= _autoCompleteThrottleTime)
+            {
+                return;
+            }
+            lastFill = DateTime.Now;
+
+            // clear and add keywords from itemclasses and stash items
+            autoComplete.ClearKeywords();
+            autoComplete.AddKeywords(ItemClasses.SearchTermMap.Keys.Select(x => "@" + x));
+            autoComplete.AddGridToKeywords(grid);
         }
     }
 }

--- a/StashSearch/Utils/AbstractSearchController.cs
+++ b/StashSearch/Utils/AbstractSearchController.cs
@@ -7,7 +7,6 @@ namespace StashSearch.Utils
     {
         public bool IsSearchedState;
         public string CurrentSearchString;
-        public bool IsTrader;
         public StashGridClass SearchedGrid;
         public string ParentGridId;
 

--- a/StashSearch/Utils/AutoCompleteComponent.cs
+++ b/StashSearch/Utils/AutoCompleteComponent.cs
@@ -2,6 +2,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using BepInEx;
+using EFT.Hideout;
 using EFT.InventoryLogic;
 using TMPro;
 using UnityEngine;
@@ -11,8 +13,11 @@ namespace StashSearch.Utils
     public class AutoCompleteComponent : MonoBehaviour
     {
         private TMP_InputField _inputField;
-        private char[] _trimChars = [' ', ',', '.', '/', '\\'];
-        private char[] _ignoreCharacters = ['(', ')', '[', ']', '"', '\''];
+
+        private static readonly char[] TRIM_CHARS = [' ', ',', '.', '/', '\\'];
+        private static readonly char[] REMOVE_CHARS = ['(', ')', '[', ']', '"', '\''];
+        private static readonly int MIN_KEYWORD_LENGTH = 2;
+
         private string _lastSearch;
         private string _lastSuggested;
 
@@ -53,10 +58,16 @@ namespace StashSearch.Utils
                 return;
             }
 
+            // FIXME: try and find a good way to bomb out if current caret is not at the end
+            // PROBLEM: caret position is not reliable here
+
             _lastSearch = thisSearch;
 
+            // split on commas for multi-searches, only use the last of the split
+            var splitSearch = thisSearch.Split(',');
+
             // find any available autocomplete, bomb if none
-            var autoCompleteSuffix = FindAutoCompleteSuffix(thisSearch);
+            var autoCompleteSuffix = FindAutoCompleteSuffix(splitSearch.Last());
             if (autoCompleteSuffix.IsNullOrEmpty())
             {
                 return;
@@ -77,12 +88,19 @@ namespace StashSearch.Utils
                 _inputField.selectionFocusPosition = caretPos + autoCompleteSuffix.Length;
                 _inputField.ForceLabelUpdate();
             });
-
-            Plugin.Log.LogDebug($"search: {thisSearch} autocomplete: {autoCompleteSuffix}");
         }
 
         private string FindAutoCompleteSuffix(string searchPrefix)
         {
+            // remove any starting spaces
+            searchPrefix = searchPrefix.TrimStart(' ');
+
+            // don't suggest if prefix is nothing
+            if (searchPrefix.IsNullOrWhiteSpace())
+            {
+                return string.Empty;
+            }
+
             // find keyword that matches our prefix
             var matches = _searchKeywords.Where(keywordPair => keywordPair.Key.StartsWith(searchPrefix));
             if (matches.IsNullOrEmpty())
@@ -90,13 +108,19 @@ namespace StashSearch.Utils
                 return string.Empty;
             }
 
-            // get the match with the largest count
-            var bestMatch = matches.OrderByDescending(keywordPair => keywordPair.Value).First().Key;
+            // get the match with the largest count, then the shortest autocomplete
+            var bestMatch = matches.OrderByDescending(keywordPair => keywordPair.Value)
+                                   .ThenByDescending(keywordPair => keywordPair.Key.Length)
+                                   .First().Key;
 
             // remove the prefix to return the suffix
             return bestMatch.Remove(bestMatch.IndexOf(searchPrefix), searchPrefix.Length);
         }
 
+        /// <summary>
+        /// Adds a keyword to the autocomplete
+        /// </summary>
+        /// <param name="keyword">keyword to add</param>
         public void AddKeyword(string keyword)
         {
             if (!_searchKeywords.ContainsKey(keyword))
@@ -109,6 +133,10 @@ namespace StashSearch.Utils
             }
         }
 
+        /// <summary>
+        /// Adds multiple keywords to the autocomplete
+        /// </summary>
+        /// <param name="keywords">keywords to add</param>
         public void AddKeywords(IEnumerable<string> keywords)
         {
             foreach (var keyword in keywords)
@@ -117,15 +145,21 @@ namespace StashSearch.Utils
             }
         }
 
+        /// <summary>
+        /// Splits a string, cleans it up, and adds each component to the autocomplete as keywords.
+        /// Duplicate words are condensed to a single keyword count
+        /// </summary>
+        /// <param name="toBeSplit">string to split and add</param>
         public void SplitStringAndAddToKeywords(string toBeSplit)
         {
             string[] splitString = toBeSplit.Split(' ');
+            HashSet<string> keywords = new();
 
             foreach (var untrimmedKeyword in splitString)
             {
                 // trim the ends and then remove the ignore characters from the string
-                var keyword = untrimmedKeyword.Trim(_trimChars);
-                foreach (var ignoreCharacter in _ignoreCharacters)
+                var keyword = untrimmedKeyword.Trim(TRIM_CHARS);
+                foreach (var ignoreCharacter in REMOVE_CHARS)
                 {
                     if (keyword.Contains(ignoreCharacter))
                     {
@@ -133,22 +167,38 @@ namespace StashSearch.Utils
                     }
                 }
 
-                if (string.IsNullOrWhiteSpace(keyword))
+                // bomb out before adding empty or too short of keywords
+                if (string.IsNullOrWhiteSpace(keyword) || keyword.Length <= MIN_KEYWORD_LENGTH)
                 {
                     continue;
                 }
 
-                AddKeyword(keyword);
+                keywords.Add(keyword);
             }
+
+            AddKeywords(keywords);
         }
 
+        /// <summary>
+        /// Adds a EFT item to the keywords by splitting the short name and long name into individual keywords
+        /// Duplicate words are condensed to a single keyword count
+        /// </summary>
+        /// <param name="item"></param>
         public void AddItemToKeywords(Item item)
         {
-            // add all of the possible auto completes for this item
-            SplitStringAndAddToKeywords(item.LocalizedShortName().ToLower());
-            SplitStringAndAddToKeywords(item.LocalizedName().ToLower());
+            // add full names as keywords
+            AddKeyword(item.LocalizedName().ToLower());
+            AddKeyword(item.LocalizedShortName().ToLower());
+
+            // add split words
+            // add the short name and long name together to be split, this ensures that duplicate words don't count more
+            SplitStringAndAddToKeywords($"{item.LocalizedShortName().ToLower()} {item.LocalizedName().ToLower()}");
         }
 
+        /// <summary>
+        /// Adds all contained EFT items in EFT grid to keywords, recursive to LootItemClass items
+        /// </summary>
+        /// <param name="gridToParse">grid to add</param>
         public void AddGridToKeywords(StashGridClass gridToParse) 
         {
             try
@@ -174,6 +224,9 @@ namespace StashSearch.Utils
             }
         }
 
+        /// <summary>
+        /// Clears keywords from internal dictionary
+        /// </summary>
         public void ClearKeywords()
         {
             _searchKeywords.Clear();

--- a/StashSearch/Utils/AutoCompleteComponent.cs
+++ b/StashSearch/Utils/AutoCompleteComponent.cs
@@ -1,0 +1,178 @@
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using TMPro;
+using UnityEngine;
+
+namespace StashSearch.Utils
+{
+    public class AutoCompleteComponent : MonoBehaviour
+    {
+        private TMP_InputField _inputField;
+        private char[] _trimChars = [' ', ',', '.', '/', '\\'];
+        private string _lastSearch;
+        private string _lastSuggested;
+        private int _forceCaret;
+        private int _forceSelection;
+        private bool _shouldForceSelect;
+
+        private Dictionary<string, int> _searchKeywords = new();
+
+        public AutoCompleteComponent() 
+        {
+        }
+
+        private void Awake()
+        {
+            _inputField = gameObject.GetComponentInChildren<TMP_InputField>();
+            _inputField.onValueChanged.AddListener(OnInputValueChanged);
+            _inputField.onEndEdit.AddListener(delegate { _lastSearch = string.Empty; _lastSuggested = string.Empty; });
+        }
+
+        private void LateUpdate()
+        {
+            if (_shouldForceSelect)
+            {
+                _inputField.caretPosition = _forceCaret;
+                _inputField.selectionAnchorPosition = _forceCaret;
+                _inputField.selectionFocusPosition = _forceSelection;
+                _inputField.ForceLabelUpdate();
+
+                _shouldForceSelect = false;
+            }
+        }
+
+        private void OnInputValueChanged(string thisSearch)
+        {
+            // don't trigger on empty search
+            if (thisSearch.IsNullOrEmpty())
+            {
+                _lastSearch = string.Empty;
+                return;
+            }
+
+            // don't allow suggested search to go for autocomplete
+            if (thisSearch == _lastSuggested)
+            {
+                return;
+            }
+
+            // allow for backspace without any autocomplete during
+            if (!_lastSearch.IsNullOrEmpty() && _lastSearch.StartsWith(thisSearch))
+            {
+                return;
+            }
+
+            _lastSearch = thisSearch;
+
+            // find any available autocomplete, bomb if none
+            var autoCompleteSuffix = FindAutoCompleteSuffix(thisSearch);
+            if (autoCompleteSuffix.IsNullOrEmpty())
+            {
+                return;
+            }
+
+            // save our caret position for later, before setting text, which will modify it
+            _forceCaret = thisSearch.Length;
+
+            // set our text to contain the auto complete text
+            _lastSuggested = thisSearch + autoCompleteSuffix;
+            _inputField.text = thisSearch + autoCompleteSuffix;
+
+            // force a refresh on next frame, since this will not work on the same frame for whatever reason
+            _forceSelection = _forceCaret + autoCompleteSuffix.Length;
+            _shouldForceSelect = true;
+
+            Plugin.Log.LogDebug($"search: {thisSearch} autocomplete: {autoCompleteSuffix}");
+        }
+
+        private string FindAutoCompleteSuffix(string searchPrefix)
+        {
+            // find keyword that matches our prefix
+            var matches = _searchKeywords.Where(keywordPair => keywordPair.Key.StartsWith(searchPrefix));
+            if (matches.IsNullOrEmpty())
+            {
+                return string.Empty;
+            }
+
+            // return the most likely one
+            var bestMatch = matches.OrderByDescending(keywordPair => keywordPair.Value).First().Key;
+
+            // remove the first occurance of prefix
+            return bestMatch.Remove(bestMatch.IndexOf(searchPrefix), searchPrefix.Length);
+        }
+
+        public void ParseKeywordsFromGrid(StashGridClass gridToParse)
+        {
+            _searchKeywords.Clear();
+
+            AddItemClassKeywords();
+
+            // Recursively parse this grid, adding possible keywords
+            ParseKeywordsFromGridHelper(gridToParse);
+        }
+
+        private void AddItemClassKeywords()
+        {
+            foreach (var keyword in ItemClasses.SearchTermMap.Keys)
+            {
+                _searchKeywords["@" + keyword] = 1;
+            }
+        }
+
+        private void ParseKeywordsFromGridHelper(StashGridClass gridToParse) 
+        {
+            try
+            { 
+                // Iterate over all child items on the grid
+                foreach (var gridItem in gridToParse.ContainedItems.ToArray())
+                {
+                    var item = gridItem.Key;
+
+                    // add all of the possible auto completes for this word
+                    SplitStringAndAddToKeywords(item.LocalizedShortName().ToLower());
+                    SplitStringAndAddToKeywords(item.LocalizedName().ToLower());
+                    SplitStringAndAddToKeywords(item.Template._parent.ToLower());
+
+                    if (gridItem.Key is LootItemClass lootItem && lootItem.Grids.Length > 0)
+                    {
+                        // Iterate over all grids on the item, and recursively call the ParseKeywordsHelper method
+                        foreach (var subGrid in lootItem.Grids)
+                        {
+                            ParseKeywordsFromGridHelper(subGrid);
+                        }
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Keyword generation exception:", e);
+            }
+        }
+
+        private void SplitStringAndAddToKeywords(string str)
+        {
+            string[] splitString = str.Split(' ');
+
+            foreach (var untrimmedKeyword in splitString)
+            {
+                var keyword = untrimmedKeyword.Trim(_trimChars);
+                if (string.IsNullOrWhiteSpace(keyword))
+                {
+                    continue;
+                }
+
+                if (!_searchKeywords.ContainsKey(keyword))
+                {
+                    _searchKeywords[keyword] = 1;
+                }
+                else
+                {
+                    _searchKeywords[keyword] = _searchKeywords[keyword] + 1;
+                }
+            }
+        }
+    }
+}

--- a/StashSearch/Utils/InputFieldAutoComplete.cs
+++ b/StashSearch/Utils/InputFieldAutoComplete.cs
@@ -1,16 +1,13 @@
-
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using BepInEx;
-using EFT.Hideout;
 using EFT.InventoryLogic;
 using TMPro;
-using UnityEngine;
 
 namespace StashSearch.Utils
 {
-    public class AutoCompleteComponent : MonoBehaviour
+    public class InputFieldAutoComplete
     {
         private TMP_InputField _inputField;
 
@@ -23,13 +20,10 @@ namespace StashSearch.Utils
 
         private Dictionary<string, int> _searchKeywords = new();
 
-        public AutoCompleteComponent() 
+        public InputFieldAutoComplete(TMP_InputField inputField) 
         {
-        }
+            _inputField = inputField;
 
-        private void Awake()
-        {
-            _inputField = gameObject.GetComponentInChildren<TMP_InputField>();
             _inputField.onValueChanged.AddListener(OnInputValueChanged);
             _inputField.onEndEdit.AddListener(delegate {
                     _lastSearch = string.Empty;


### PR DESCRIPTION
This adds highlight-based (no dropdown) autocomplete to all current search bars based on item short names, long names, and word fragments from both as well as all item classes search terms. Autocompletes are ordered first by number of items matching, then by the shortest match. Autocomplete should be relatively easy to add to other search boxes as well.

This was a bit of a larger feature to just hack on, but I couldn't get it out of my head every time that I used the search in my current play-through.

A pre-compiled preview (no version number changes in this yet): [StashSearch.zip](https://github.com/CJ-SPT/StashSearch/files/15004675/StashSearch.zip)
