### PR TITLE
Bugfix: Close open GridWindows for hidden items

### DIFF
--- a/StashSearch/Plugin.cs
+++ b/StashSearch/Plugin.cs
@@ -2,14 +2,12 @@
 using BepInEx.Logging;
 using DrakiaXYZ.VersionChecker;
 using EFT.UI;
-using HarmonyLib;
 using StashSearch.Config;
 using StashSearch.Patches;
 using StashSearch.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using UnityEngine;
 
@@ -36,10 +34,6 @@ namespace StashSearch
 
         internal static List<AbstractSearchController> SearchControllers = new List<AbstractSearchController>();
 
-        public static FieldInfo WindowListField;
-        public static FieldInfo WindowLootItemField;
-        public static FieldInfo WindowContainerWindowField;
-
         internal void Awake()
         {
             if (!VersionChecker.CheckEftVersion(Logger, Info, Config))
@@ -61,12 +55,6 @@ namespace StashSearch
             new OnScreenChangedPatch().Enable();
             new SortingTablePatch().Enable();
             new CanQuickMoveToPatch().Enable();
-
-            WindowListField = AccessTools.Field(typeof(ItemUiContext), "list_0");
-            WindowLootItemField = AccessTools.GetDeclaredFields(typeof(GridWindow)).Single(x => x.FieldType == typeof(LootItemClass));
-
-            Type windowContainerType = AccessTools.FirstInner(typeof(ItemUiContext), x => x.GetField("WindowType") != null);
-            WindowContainerWindowField = AccessTools.Field(windowContainerType, "Window");
         }
 
         private void Start()

--- a/StashSearch/Plugin.cs
+++ b/StashSearch/Plugin.cs
@@ -2,12 +2,14 @@
 using BepInEx.Logging;
 using DrakiaXYZ.VersionChecker;
 using EFT.UI;
+using HarmonyLib;
 using StashSearch.Config;
 using StashSearch.Patches;
 using StashSearch.Utils;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using UnityEngine;
 
@@ -34,6 +36,10 @@ namespace StashSearch
 
         internal static List<AbstractSearchController> SearchControllers = new List<AbstractSearchController>();
 
+        public static FieldInfo WindowListField;
+        public static FieldInfo WindowLootItemField;
+        public static FieldInfo WindowContainerWindowField;
+
         internal void Awake()
         {
             if (!VersionChecker.CheckEftVersion(Logger, Info, Config))
@@ -55,6 +61,12 @@ namespace StashSearch
             new OnScreenChangedPatch().Enable();
             new SortingTablePatch().Enable();
             new CanQuickMoveToPatch().Enable();
+
+            WindowListField = AccessTools.Field(typeof(ItemUiContext), "list_0");
+            WindowLootItemField = AccessTools.GetDeclaredFields(typeof(GridWindow)).Single(x => x.FieldType == typeof(LootItemClass));
+
+            Type windowContainerType = AccessTools.FirstInner(typeof(ItemUiContext), x => x.GetField("WindowType") != null);
+            WindowContainerWindowField = AccessTools.Field(windowContainerType, "Window");
         }
 
         private void Start()


### PR DESCRIPTION
Found an issue that open `GridWindow`s from items that are hidden lead to broken exceptions and broken functionality while the item is hidden. This fixes it by simply closing the `GridWindow`s that are hidden. I used a bit of inspiration from [Drakia's QuickMoveToContainer](https://github.com/DrakiaXYZ/SPT-QuickMoveToContainer/blob/master/QuickMovePlugin.cs) to get a starting point to get the open windows and I'm unsure to the license implications.