### PR TITLE
Add additional item classes

### DIFF
--- a/StashSearch/Utils/InputFieldAutoComplete.cs
+++ b/StashSearch/Utils/InputFieldAutoComplete.cs
@@ -104,7 +104,7 @@ namespace StashSearch.Utils
 
             // get the match with the largest count, then the shortest autocomplete
             var bestMatch = matches.OrderByDescending(keywordPair => keywordPair.Value)
-                                   .ThenByDescending(keywordPair => keywordPair.Key.Length)
+                                   .ThenBy(keywordPair => keywordPair.Key.Length)
                                    .First().Key;
 
             // remove the prefix to return the suffix


### PR DESCRIPTION
Add some additional item classes:

- special
- money/cash
- lightbleed/bandage
- heavybleed/tourniquet
- fracture/splint
- concussion
- painkiller
- surgerykit
- food/energy
- drink/hydration

Other changes:
- Food and drink split into different categories, new `foodanddrink` class
- Actually order by smaller auto suggests