### PR TITLE
Fix issue with selling/buying while player stash is searched

### DIFF
--- a/StashSearch/Patches/TraderAssortmentControllerClassPurchasePatch.cs
+++ b/StashSearch/Patches/TraderAssortmentControllerClassPurchasePatch.cs
@@ -1,0 +1,23 @@
+﻿using Aki.Reflection.Patching;
+using HarmonyLib;
+using System.Reflection;
+
+namespace StashSearch.Patches
+{
+    internal class TraderAssortmentControllerClassPurchasePatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return AccessTools.Method(typeof(TraderAssortmentControllerClass), nameof(TraderAssortmentControllerClass.Purchase));
+        }
+
+        /// <summary>
+        /// Prevents loss of purchased item while searching
+        /// </summary>
+        [PatchPrefix]
+        public static void PatchPrefix()
+        {
+            Plugin.Instance.TraderScreenComponent.OnTraderTransaction();
+        }
+    }
+}

--- a/StashSearch/Patches/TraderAssortmentControllerClassSellPatch.cs
+++ b/StashSearch/Patches/TraderAssortmentControllerClassSellPatch.cs
@@ -1,0 +1,23 @@
+﻿using Aki.Reflection.Patching;
+using HarmonyLib;
+using System.Reflection;
+
+namespace StashSearch.Patches
+{
+    internal class TraderAssortmentControllerClassSellPatch : ModulePatch
+    {
+        protected override MethodBase GetTargetMethod()
+        {
+            return AccessTools.Method(typeof(TraderAssortmentControllerClass), nameof(TraderAssortmentControllerClass.Sell));
+        }
+
+        /// <summary>
+        /// Prevents session loss of cash on trader sell
+        /// </summary>
+        [PatchPostfix]
+        public static void PatchPostfix()
+        {
+            Plugin.Instance.TraderScreenComponent.OnTraderTransaction();
+        }
+    }
+}

--- a/StashSearch/Patches/TraderDealScreenShowPatch.cs
+++ b/StashSearch/Patches/TraderDealScreenShowPatch.cs
@@ -24,7 +24,7 @@ namespace StashSearch.Patches
                 return;
             }
 
-            TraderScreenComponent.MaybeChangingTrader(trader);
+            TraderScreenComponent.OnMaybeChangingTrader(trader);
         }
     }
 }

--- a/StashSearch/Plugin.cs
+++ b/StashSearch/Plugin.cs
@@ -30,7 +30,9 @@ namespace StashSearch
         public static GameObject SearchRestoreButtonPrefab;
 
         public GameObject StashSearchGameObject;
+        public StashComponent StashComponent;
         public GameObject TraderSearchGameObject;
+        public TraderScreenComponent TraderScreenComponent;
 
         internal static List<AbstractSearchController> SearchControllers = new List<AbstractSearchController>();
 
@@ -55,6 +57,8 @@ namespace StashSearch
             new OnScreenChangedPatch().Enable();
             new SortingTablePatch().Enable();
             new CanQuickMoveToPatch().Enable();
+            new TraderAssortmentControllerClassSellPatch().Enable();
+            new TraderAssortmentControllerClassPurchasePatch().Enable();
         }
 
         private void Start()
@@ -67,6 +71,7 @@ namespace StashSearch
             // create a new gameobject parented under InventoryScreen with our component on it
             StashSearchGameObject = new GameObject("StashSearch", typeof(StashComponent));
             StashSearchGameObject.transform.SetParent(inventory.transform);
+            StashComponent = StashSearchGameObject.GetComponent<StashComponent>();
             return StashSearchGameObject;
         }
 
@@ -75,6 +80,7 @@ namespace StashSearch
             // create a new gameobject parented under TraderScreensGroup with our component on it
             TraderSearchGameObject = new GameObject("TraderSearch", typeof(TraderScreenComponent));
             TraderSearchGameObject.transform.SetParent(traderScreensGroup.transform);
+            TraderScreenComponent = TraderSearchGameObject.GetComponent<TraderScreenComponent>();
             return TraderSearchGameObject;
         }
 

--- a/StashSearch/TraderScreenComponent.cs
+++ b/StashSearch/TraderScreenComponent.cs
@@ -272,7 +272,7 @@ namespace StashSearch
         private void ClearStashSearch(bool clearText = true, bool checkTable = true)
         {
             // avoid losing items if trading table not empty
-            if (checkTable && CheckTradingTableEmpty())
+            if (checkTable && !CheckTradingTableEmpty())
             {
                 return;
             }


### PR DESCRIPTION
This resolves the issue of selling items while searched not taking effect until game restart and the potential for item loss on purchasing an item while searched. It just clears the search before profile is changed in both of those cases. 

Removed coroutines as discussed in Discord -- this has the bonus of fixing the flashing between active searches.